### PR TITLE
doc(README): add notes on timestamps for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ expedite the process.
 #### Details to add an event
 
 Event information is stored in the `_events/` directory. To add a new a event, create a file in
-that folder using a `.html` or `.md` file extension. Start your file with the following content:
+that folder using a `.html` or `.md` file extension. Start your file with the following content
+(or copy the template file `event-frontmatter.txt`):
 
 ```md
 ---
@@ -56,7 +57,8 @@ The first field to add is the title; between the sets of dashes add a like that 
 On a new line, add a line that begins with `start-date: ` and then format the start date of the
 event using ISO 8601 format including the event time zone. For example,
 `2023-04-17T22:07:43-04:00`. Then add a line that begins with `end-date: ` and do the same for
-end date/time of the event.
+end date/time of the event. Remember that Eastern Time in the US is `-04:00` during the
+summer (EDT) and `-05:00` during the winter (EST).
 
 Next, add a line that begins with `location: ` and add a human-readable location for where the
 event takes place. This should include the name of the building/business and the city where the

--- a/_events/2024-01-maoc-meetup.md
+++ b/_events/2024-01-maoc-meetup.md
@@ -1,6 +1,6 @@
 ---
-start-date: 2024-01-24T17:30:00-04:00
-end-date: 2024-01-24T19:00:00-04:00
+start-date: 2024-01-24T17:30:00-05:00
+end-date: 2024-01-24T19:00:00-05:00
 title: Mid-Atlantic OSCAL Community Meetup (January 2024)
 location: Solace Outpost (Large Meeting Room)
 map-link: https://goo.gl/maps/Zat8RT1revNvnW9G6

--- a/event-frontmatter.txt
+++ b/event-frontmatter.txt
@@ -1,4 +1,7 @@
 ---
+# Timestamps should be in RFC 3339 format. US Eastern Time is 
+# UTC-04:00 from Mar-Nov
+# UTC-05:00 from Nov-Mar
 start-date:
 end-date:
 title:


### PR DESCRIPTION
The January meetup was shown as being at 4:30PM ET due to the UTC offset in the front matter being `-04:00` while the current east coast time is `-05:00`. This corrects that for this event (even though it's over) and adds a note to the README and the `event-frontmatter.txt` template file about the correct offsets for Eastern Time, which is likely to be the most relevant timezone for the community.

The formatting is done client side as well but I am not sure whether there is conversion to the user's
local timezone.