### PR TITLE
Update GitHub Actions to latest versions for deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@086ffb1a2090c870a3f881cc91ea83aa4243d408 # v1.195.0
         with:
@@ -34,13 +34,13 @@ jobs:
           cache-version: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying GitHub Pages by upgrading several GitHub Actions to their latest major versions. These changes help ensure better security, performance, and compatibility with the latest features.

**GitHub Actions version upgrades:**

- Upgraded `actions/checkout` from v3 to v4 in `.github/workflows/deploy-pages.yml` to use the latest improvements and fixes.
- Upgraded `actions/configure-pages` from v3 to v4 in `.github/workflows/deploy-pages.yml` for improved Pages configuration support.
- Upgraded `actions/upload-pages-artifact` from v1 to v3 in `.github/workflows/deploy-pages.yml` for better artifact handling and compatibility.
- Upgraded `actions/deploy-pages` from v2 to v4 in `.github/workflows/deploy-pages.yml` to use the latest deployment features and security updates.