### PR TITLE
Update links and titles for BSI Grundschutz++ OSCAL tools

### DIFF
--- a/_tools/bsi-gs-plusplus-oscal-components.md
+++ b/_tools/bsi-gs-plusplus-oscal-components.md
@@ -2,7 +2,7 @@
 title: BSI Grundschutz++ OSCAL Components Creator
 author: NTT Data
 license: Apache-2.0 license
-link: https://github.com/AG-3-Nutzergenerierte-Inhalte/AG-3-Tooling/tree/main/ai_tool
+link: https://github.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/tree/main/Gpp-ai-tool
 category:
   - open-source
   - free

--- a/_tools/bsi-gs-plusplus-poam-workbench.md
+++ b/_tools/bsi-gs-plusplus-poam-workbench.md
@@ -1,8 +1,8 @@
 ---
-title: BSI Grundschutz++ POA&M Workbench
+title: BSI Grundschutz++ OSCAL Workbench
 author: NTT Data
 license: CC BY-SA 4.0
-link: https://github.com/AG-3-Nutzergenerierte-Inhalte/Stand-der-Technik-Bibliothek/tree/main/Nutzergenerierte-Inhalte/tools
+link: https://github.com/NTT-Data-Deutschland-SE/Grundschutz-Plus-Plus-Tools/tree/main/One-Page-Apps
 category:
   - open-source
   - free


### PR DESCRIPTION
This pull request updates metadata for two BSI Grundschutz++ tool listings, correcting titles and updating repository links to their new locations. These changes improve the accuracy and maintainability of the documentation.

Tool metadata updates:

* Updated the repository link in `_tools/bsi-gs-plusplus-oscal-components.md` to point to the new GitHub location under `NTT-Data-Deutschland-SE` and kept the tool title unchanged.
* Changed the title in `_tools/bsi-gs-plusplus-poam-workbench.md` from "POA&M Workbench" to "OSCAL Workbench" and updated the repository link to the new GitHub location under `NTT-Data-Deutschland-SE`.